### PR TITLE
fix applest-atem package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Filip Hanes <filip.hanes@pm.me>",
   "license": "MIT",
   "dependencies": {
-    "applest-atem": "0.4.2",
+    "applest-atem": "0.2.4",
     "express": "^4.16.1",
     "express-fileupload": "^1.1.5",
     "express-ws": "^4.0.0",


### PR DESCRIPTION
Typo in version string corrected to allow a smooth `npm install`